### PR TITLE
Updating years to 2025 and updating read-mes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 # Intel® Optimized Cloud Modules for Terraform
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS Aurora MySQL Module
 This code creates an Amazon Aurora instance and RDS cluster for MySQL. The instance is created on an Intel Icelake instance R6i.large by default. The instance is pre-configured with parameters within the database parameter group that is optimized for Intel architecture. The goal of this module is to get you started with a database configured to run best on Intel architecture.

--- a/examples/terraform-intel-aws-mysql-expanded-parameters/README.md
+++ b/examples/terraform-intel-aws-mysql-expanded-parameters/README.md
@@ -4,7 +4,7 @@
 
 # Intel® Optimized Cloud Modules for Terraform
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS Aurora MySQL Module - Expanded Parameters Example
 
@@ -22,6 +22,8 @@ The MySQL Optimizations were based off [Intel Xeon Tuning guides](<https://www.i
 By default, you will only have to pass the following variables
 ```hcl
 db_password
+subnet_id
+vpc_id
 ```
 
 variables.tf

--- a/examples/terraform-intel-aws-mysql-replica/README.md
+++ b/examples/terraform-intel-aws-mysql-replica/README.md
@@ -15,7 +15,6 @@ As you configure your application's environment, choose the configurations for y
 The MySQL Optimizations were based off [Intel Xeon Tunning guides](<https://www.intel.com/content/www/us/en/developer/articles/guide/open-source-database-tuning-guide-on-xeon-systems.html>)
 
 ## Usage
-# add a comment
 
 
 By default, you will only have to pass the following variables

--- a/examples/terraform-intel-aws-mysql-replica/README.md
+++ b/examples/terraform-intel-aws-mysql-replica/README.md
@@ -4,7 +4,7 @@
 
 # Intel® Optimized Cloud Modules for Terraform
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS Aurora MySQL Module - Read Replica Example
 
@@ -15,12 +15,14 @@ As you configure your application's environment, choose the configurations for y
 The MySQL Optimizations were based off [Intel Xeon Tunning guides](<https://www.intel.com/content/www/us/en/developer/articles/guide/open-source-database-tuning-guide-on-xeon-systems.html>)
 
 ## Usage
-
+# add a comment
 
 
 By default, you will only have to pass the following variables
 ```hcl
 db_password
+subnet_id
+vpc_id
 ```
 
 variables.tf


### PR DESCRIPTION
Changing the copy-right years to 2025
The example read-mes adding default variables (vpc_id, subnet_id in addition to default_pass)
Ran module successfully